### PR TITLE
🐛 Fix QCA wordmark replay and cell polarization

### DIFF
--- a/src/mnt/bench/static/bench.js
+++ b/src/mnt/bench/static/bench.js
@@ -2,6 +2,15 @@
   "use strict";
 
   const byId = (id) => document.getElementById(id);
+  window.addEventListener("pageshow", () => {
+    const wordmark = document.querySelector(".circuit-art img");
+    if (!wordmark || window.matchMedia("(prefers-reduced-motion: reduce)").matches) return;
+    // A cached SVG image can retain its finished animation, including after browser Back.
+    const source = new URL(wordmark.src);
+    source.searchParams.set("replay", Date.now());
+    wordmark.src = source.href;
+  });
+
   let notificationTimer;
   function notify(message) {
     const notification = byId("notification");

--- a/src/mnt/bench/static/qca_wordmark.svg
+++ b/src/mnt/bench/static/qca_wordmark.svg
@@ -42,157 +42,158 @@
       <circle cx="20" cy="20" r="3.2" fill="none" stroke="#2858ac"/>
     </symbol>
   </defs>
+  <!-- Straight strokes preserve polarization; diagonal-only joins invert it. -->
   <g data-word="MNT">
     <g data-letter="M" transform="translate(274 50)" style="--letter-delay: 324ms">
       <use href="#cell-a" x="0" y="0" width="28" height="28"/>
       <use href="#cell-a" x="128" y="0" width="28" height="28"/>
-      <use href="#cell-b" x="0" y="32" width="28" height="28"/>
+      <use href="#cell-a" x="0" y="32" width="28" height="28"/>
       <use href="#cell-a" x="32" y="32" width="28" height="28"/>
       <use href="#cell-a" x="96" y="32" width="28" height="28"/>
-      <use href="#cell-b" x="128" y="32" width="28" height="28"/>
+      <use href="#cell-a" x="128" y="32" width="28" height="28"/>
       <use href="#cell-a" x="0" y="64" width="28" height="28"/>
-      <use href="#cell-a" x="64" y="64" width="28" height="28"/>
+      <use href="#cell-b" x="64" y="64" width="28" height="28"/>
       <use href="#cell-a" x="128" y="64" width="28" height="28"/>
-      <use href="#cell-b" x="0" y="96" width="28" height="28"/>
+      <use href="#cell-a" x="0" y="96" width="28" height="28"/>
       <use href="#cell-b" x="64" y="96" width="28" height="28"/>
-      <use href="#cell-b" x="128" y="96" width="28" height="28"/>
+      <use href="#cell-a" x="128" y="96" width="28" height="28"/>
       <use href="#cell-a" x="0" y="128" width="28" height="28"/>
       <use href="#cell-a" x="128" y="128" width="28" height="28"/>
-      <use href="#cell-b" x="0" y="160" width="28" height="28"/>
-      <use href="#cell-b" x="128" y="160" width="28" height="28"/>
+      <use href="#cell-a" x="0" y="160" width="28" height="28"/>
+      <use href="#cell-a" x="128" y="160" width="28" height="28"/>
       <use href="#cell-a" x="0" y="192" width="28" height="28"/>
       <use href="#cell-a" x="128" y="192" width="28" height="28"/>
     </g>
     <g data-letter="N" transform="translate(498 50)" style="--letter-delay: 548ms">
-      <use href="#cell-b" x="0" y="0" width="28" height="28"/>
-      <use href="#cell-b" x="128" y="0" width="28" height="28"/>
+      <use href="#cell-a" x="0" y="0" width="28" height="28"/>
+      <use href="#cell-a" x="128" y="0" width="28" height="28"/>
       <use href="#cell-a" x="0" y="32" width="28" height="28"/>
-      <use href="#cell-b" x="32" y="32" width="28" height="28"/>
+      <use href="#cell-a" x="32" y="32" width="28" height="28"/>
       <use href="#cell-a" x="128" y="32" width="28" height="28"/>
-      <use href="#cell-b" x="0" y="64" width="28" height="28"/>
+      <use href="#cell-a" x="0" y="64" width="28" height="28"/>
       <use href="#cell-a" x="32" y="64" width="28" height="28"/>
-      <use href="#cell-b" x="128" y="64" width="28" height="28"/>
+      <use href="#cell-a" x="128" y="64" width="28" height="28"/>
       <use href="#cell-a" x="0" y="96" width="28" height="28"/>
-      <use href="#cell-a" x="64" y="96" width="28" height="28"/>
+      <use href="#cell-b" x="64" y="96" width="28" height="28"/>
       <use href="#cell-a" x="128" y="96" width="28" height="28"/>
-      <use href="#cell-b" x="0" y="128" width="28" height="28"/>
+      <use href="#cell-a" x="0" y="128" width="28" height="28"/>
       <use href="#cell-a" x="96" y="128" width="28" height="28"/>
-      <use href="#cell-b" x="128" y="128" width="28" height="28"/>
+      <use href="#cell-a" x="128" y="128" width="28" height="28"/>
       <use href="#cell-a" x="0" y="160" width="28" height="28"/>
-      <use href="#cell-b" x="96" y="160" width="28" height="28"/>
+      <use href="#cell-a" x="96" y="160" width="28" height="28"/>
       <use href="#cell-a" x="128" y="160" width="28" height="28"/>
-      <use href="#cell-b" x="0" y="192" width="28" height="28"/>
-      <use href="#cell-b" x="128" y="192" width="28" height="28"/>
+      <use href="#cell-a" x="0" y="192" width="28" height="28"/>
+      <use href="#cell-a" x="128" y="192" width="28" height="28"/>
     </g>
     <g data-letter="T" transform="translate(722 50)" style="--letter-delay: 772ms">
       <use href="#cell-a" x="0" y="0" width="28" height="28"/>
-      <use href="#cell-b" x="32" y="0" width="28" height="28"/>
+      <use href="#cell-a" x="32" y="0" width="28" height="28"/>
       <use href="#cell-a" x="64" y="0" width="28" height="28"/>
-      <use href="#cell-b" x="96" y="0" width="28" height="28"/>
+      <use href="#cell-a" x="96" y="0" width="28" height="28"/>
       <use href="#cell-a" x="128" y="0" width="28" height="28"/>
-      <use href="#cell-b" x="64" y="32" width="28" height="28"/>
+      <use href="#cell-a" x="64" y="32" width="28" height="28"/>
       <use href="#cell-a" x="64" y="64" width="28" height="28"/>
-      <use href="#cell-b" x="64" y="96" width="28" height="28"/>
+      <use href="#cell-a" x="64" y="96" width="28" height="28"/>
       <use href="#cell-a" x="64" y="128" width="28" height="28"/>
-      <use href="#cell-b" x="64" y="160" width="28" height="28"/>
+      <use href="#cell-a" x="64" y="160" width="28" height="28"/>
       <use href="#cell-a" x="64" y="192" width="28" height="28"/>
     </g>
   </g>
   <g data-word="BENCH">
     <g data-letter="B" transform="translate(50 338)" style="--letter-delay: 388ms">
       <use href="#cell-a" x="0" y="0" width="28" height="28"/>
-      <use href="#cell-b" x="32" y="0" width="28" height="28"/>
+      <use href="#cell-a" x="32" y="0" width="28" height="28"/>
       <use href="#cell-a" x="64" y="0" width="28" height="28"/>
-      <use href="#cell-b" x="96" y="0" width="28" height="28"/>
-      <use href="#cell-b" x="0" y="32" width="28" height="28"/>
+      <use href="#cell-a" x="96" y="0" width="28" height="28"/>
+      <use href="#cell-a" x="0" y="32" width="28" height="28"/>
       <use href="#cell-b" x="128" y="32" width="28" height="28"/>
       <use href="#cell-a" x="0" y="64" width="28" height="28"/>
-      <use href="#cell-a" x="128" y="64" width="28" height="28"/>
-      <use href="#cell-b" x="0" y="96" width="28" height="28"/>
+      <use href="#cell-b" x="128" y="64" width="28" height="28"/>
+      <use href="#cell-a" x="0" y="96" width="28" height="28"/>
       <use href="#cell-a" x="32" y="96" width="28" height="28"/>
-      <use href="#cell-b" x="64" y="96" width="28" height="28"/>
+      <use href="#cell-a" x="64" y="96" width="28" height="28"/>
       <use href="#cell-a" x="96" y="96" width="28" height="28"/>
       <use href="#cell-a" x="0" y="128" width="28" height="28"/>
-      <use href="#cell-a" x="128" y="128" width="28" height="28"/>
-      <use href="#cell-b" x="0" y="160" width="28" height="28"/>
+      <use href="#cell-b" x="128" y="128" width="28" height="28"/>
+      <use href="#cell-a" x="0" y="160" width="28" height="28"/>
       <use href="#cell-b" x="128" y="160" width="28" height="28"/>
       <use href="#cell-a" x="0" y="192" width="28" height="28"/>
-      <use href="#cell-b" x="32" y="192" width="28" height="28"/>
+      <use href="#cell-a" x="32" y="192" width="28" height="28"/>
       <use href="#cell-a" x="64" y="192" width="28" height="28"/>
-      <use href="#cell-b" x="96" y="192" width="28" height="28"/>
+      <use href="#cell-a" x="96" y="192" width="28" height="28"/>
     </g>
     <g data-letter="E" transform="translate(274 338)" style="--letter-delay: 612ms">
-      <use href="#cell-b" x="0" y="0" width="28" height="28"/>
+      <use href="#cell-a" x="0" y="0" width="28" height="28"/>
       <use href="#cell-a" x="32" y="0" width="28" height="28"/>
-      <use href="#cell-b" x="64" y="0" width="28" height="28"/>
+      <use href="#cell-a" x="64" y="0" width="28" height="28"/>
       <use href="#cell-a" x="96" y="0" width="28" height="28"/>
-      <use href="#cell-b" x="128" y="0" width="28" height="28"/>
+      <use href="#cell-a" x="128" y="0" width="28" height="28"/>
       <use href="#cell-a" x="0" y="32" width="28" height="28"/>
-      <use href="#cell-b" x="0" y="64" width="28" height="28"/>
+      <use href="#cell-a" x="0" y="64" width="28" height="28"/>
       <use href="#cell-a" x="0" y="96" width="28" height="28"/>
-      <use href="#cell-b" x="32" y="96" width="28" height="28"/>
+      <use href="#cell-a" x="32" y="96" width="28" height="28"/>
       <use href="#cell-a" x="64" y="96" width="28" height="28"/>
-      <use href="#cell-b" x="96" y="96" width="28" height="28"/>
-      <use href="#cell-b" x="0" y="128" width="28" height="28"/>
+      <use href="#cell-a" x="96" y="96" width="28" height="28"/>
+      <use href="#cell-a" x="0" y="128" width="28" height="28"/>
       <use href="#cell-a" x="0" y="160" width="28" height="28"/>
-      <use href="#cell-b" x="0" y="192" width="28" height="28"/>
+      <use href="#cell-a" x="0" y="192" width="28" height="28"/>
       <use href="#cell-a" x="32" y="192" width="28" height="28"/>
-      <use href="#cell-b" x="64" y="192" width="28" height="28"/>
+      <use href="#cell-a" x="64" y="192" width="28" height="28"/>
       <use href="#cell-a" x="96" y="192" width="28" height="28"/>
-      <use href="#cell-b" x="128" y="192" width="28" height="28"/>
+      <use href="#cell-a" x="128" y="192" width="28" height="28"/>
     </g>
     <g data-letter="N" transform="translate(498 338)" style="--letter-delay: 836ms">
       <use href="#cell-a" x="0" y="0" width="28" height="28"/>
       <use href="#cell-a" x="128" y="0" width="28" height="28"/>
-      <use href="#cell-b" x="0" y="32" width="28" height="28"/>
+      <use href="#cell-a" x="0" y="32" width="28" height="28"/>
       <use href="#cell-a" x="32" y="32" width="28" height="28"/>
-      <use href="#cell-b" x="128" y="32" width="28" height="28"/>
+      <use href="#cell-a" x="128" y="32" width="28" height="28"/>
       <use href="#cell-a" x="0" y="64" width="28" height="28"/>
-      <use href="#cell-b" x="32" y="64" width="28" height="28"/>
+      <use href="#cell-a" x="32" y="64" width="28" height="28"/>
       <use href="#cell-a" x="128" y="64" width="28" height="28"/>
-      <use href="#cell-b" x="0" y="96" width="28" height="28"/>
+      <use href="#cell-a" x="0" y="96" width="28" height="28"/>
       <use href="#cell-b" x="64" y="96" width="28" height="28"/>
-      <use href="#cell-b" x="128" y="96" width="28" height="28"/>
+      <use href="#cell-a" x="128" y="96" width="28" height="28"/>
       <use href="#cell-a" x="0" y="128" width="28" height="28"/>
-      <use href="#cell-b" x="96" y="128" width="28" height="28"/>
+      <use href="#cell-a" x="96" y="128" width="28" height="28"/>
       <use href="#cell-a" x="128" y="128" width="28" height="28"/>
-      <use href="#cell-b" x="0" y="160" width="28" height="28"/>
+      <use href="#cell-a" x="0" y="160" width="28" height="28"/>
       <use href="#cell-a" x="96" y="160" width="28" height="28"/>
-      <use href="#cell-b" x="128" y="160" width="28" height="28"/>
+      <use href="#cell-a" x="128" y="160" width="28" height="28"/>
       <use href="#cell-a" x="0" y="192" width="28" height="28"/>
       <use href="#cell-a" x="128" y="192" width="28" height="28"/>
     </g>
     <g data-letter="C" transform="translate(722 338)" style="--letter-delay: 1060ms">
       <use href="#cell-a" x="32" y="0" width="28" height="28"/>
-      <use href="#cell-b" x="64" y="0" width="28" height="28"/>
+      <use href="#cell-a" x="64" y="0" width="28" height="28"/>
       <use href="#cell-a" x="96" y="0" width="28" height="28"/>
-      <use href="#cell-a" x="0" y="32" width="28" height="28"/>
-      <use href="#cell-a" x="128" y="32" width="28" height="28"/>
+      <use href="#cell-b" x="0" y="32" width="28" height="28"/>
+      <use href="#cell-b" x="128" y="32" width="28" height="28"/>
       <use href="#cell-b" x="0" y="64" width="28" height="28"/>
-      <use href="#cell-a" x="0" y="96" width="28" height="28"/>
+      <use href="#cell-b" x="0" y="96" width="28" height="28"/>
       <use href="#cell-b" x="0" y="128" width="28" height="28"/>
-      <use href="#cell-a" x="0" y="160" width="28" height="28"/>
-      <use href="#cell-a" x="128" y="160" width="28" height="28"/>
+      <use href="#cell-b" x="0" y="160" width="28" height="28"/>
+      <use href="#cell-b" x="128" y="160" width="28" height="28"/>
       <use href="#cell-a" x="32" y="192" width="28" height="28"/>
-      <use href="#cell-b" x="64" y="192" width="28" height="28"/>
+      <use href="#cell-a" x="64" y="192" width="28" height="28"/>
       <use href="#cell-a" x="96" y="192" width="28" height="28"/>
     </g>
     <g data-letter="H" transform="translate(946 338)" style="--letter-delay: 1284ms">
       <use href="#cell-a" x="0" y="0" width="28" height="28"/>
       <use href="#cell-a" x="128" y="0" width="28" height="28"/>
-      <use href="#cell-b" x="0" y="32" width="28" height="28"/>
-      <use href="#cell-b" x="128" y="32" width="28" height="28"/>
+      <use href="#cell-a" x="0" y="32" width="28" height="28"/>
+      <use href="#cell-a" x="128" y="32" width="28" height="28"/>
       <use href="#cell-a" x="0" y="64" width="28" height="28"/>
       <use href="#cell-a" x="128" y="64" width="28" height="28"/>
-      <use href="#cell-b" x="0" y="96" width="28" height="28"/>
+      <use href="#cell-a" x="0" y="96" width="28" height="28"/>
       <use href="#cell-a" x="32" y="96" width="28" height="28"/>
-      <use href="#cell-b" x="64" y="96" width="28" height="28"/>
+      <use href="#cell-a" x="64" y="96" width="28" height="28"/>
       <use href="#cell-a" x="96" y="96" width="28" height="28"/>
-      <use href="#cell-b" x="128" y="96" width="28" height="28"/>
+      <use href="#cell-a" x="128" y="96" width="28" height="28"/>
       <use href="#cell-a" x="0" y="128" width="28" height="28"/>
       <use href="#cell-a" x="128" y="128" width="28" height="28"/>
-      <use href="#cell-b" x="0" y="160" width="28" height="28"/>
-      <use href="#cell-b" x="128" y="160" width="28" height="28"/>
+      <use href="#cell-a" x="0" y="160" width="28" height="28"/>
+      <use href="#cell-a" x="128" y="160" width="28" height="28"/>
       <use href="#cell-a" x="0" y="192" width="28" height="28"/>
       <use href="#cell-a" x="128" y="192" width="28" height="28"/>
     </g>


### PR DESCRIPTION
## 🐛 Summary

- ✨ Replay the QCA wordmark on page visits, reloads, and browser Back/Forward restores by refreshing its SVG URL on `pageshow`. Respect reduced-motion preferences and leave pages without the hero untouched.
- 🎨 Correct 65 cell polarizations: horizontal/vertical strokes preserve polarization, while diagonal-only joins invert it. All 135 cell positions, letter shapes, and animation timings remain unchanged.

The wordmark remains a decorative illustration, not a simulated functional circuit. The polarization convention follows [Lent and Tougaw, Fig. 3](https://www3.nd.edu/~lent/pdf/nd/A_Device_Architecture_for_Computing_with_Quantum_Dots.pdf).

## 🧪 Checks

- ✅ Python 3.10: all 32 existing pytest tests pass.
- ✅ All applicable pre-commit checks pass.
- ✅ Chromium: visually verified initial visits, reloads, navigation links, and actual Back/Forward cache restores; verified static rendering with the native reduced-motion preference.

## 📦 Scope

- 📦 Only the JavaScript replay handler and SVG charge pattern change. No test, dependency, packaging, or benchmark-archive changes; the tracked empty archive placeholder is preserved.
